### PR TITLE
Provide the HTTP status code if the request fails and the body is empty.

### DIFF
--- a/lib/pact_broker/client/base_client.rb
+++ b/lib/pact_broker/client/base_client.rb
@@ -56,6 +56,10 @@ module PactBroker
           yield
         elsif response.code == 404
           nil
+        elsif response.code == 409
+          raise 'Conflict'
+        elsif response.body.nil? || response.body.length == 0
+          raise "Request failed with HTTP status #{response.code}"
         else
           raise response.body
         end


### PR DESCRIPTION
This gives the user something actionable in the console output.