### PR TITLE
Fix link to pact-broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A client for the Pact Broker. Publishes pacts to, and retrieves pacts from, the 
 
 ## Usage
 
-You will need an instance of a [Pact Broker](https://github.com/bethesque/pact_broker). It's URL will be used below in the configuration for the Consumer and the Provider. eg. http://pact-broker.my.org
+You will need an instance of a [Pact Broker](https://github.com/pact-foundation/pact_broker). It's URL will be used below in the configuration for the Consumer and the Provider. eg. http://pact-broker.my.org
 
 ### Consumer
 


### PR DESCRIPTION
@bethesque I keep getting confused with the two links haha. Um, I'm not sure if this is intentional or not, but I checked both repos and it looks like you're the active maintainer but the pact-foundation one is the more up-to-date one?

If I assumed incorrectly then feel free to close this :)