### PR TITLE
include task.pattern in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ require 'pact_broker/client/tasks'
 PactBroker::Client::PublicationTask.new do | task |
   require 'my_consumer/version'
   task.consumer_version = MyConsumer::VERSION
+  task.pattern = 'custom/path/to/pacts/*.json' # optional, default value is 'spec/pacts/*.json'
   task.pact_broker_base_url = "http://pact-broker.my.org"
   task.tags = ["dev"] # optional
-  task.pact_broker_basic_auth =  { username: 'basic_auth_user', password: 'basic_auth_pass'} #optional
+  task.pact_broker_basic_auth =  { username: 'basic_auth_user', password: 'basic_auth_pass'} # optional
   task.write_method = :merge # optional, this will merge the published pact into an existing pact rather than overwriting it if one exists. Not recommended, as it makes a mulch of the workflow on the broker.
 end
 ```


### PR DESCRIPTION
I use a custom pact_dir in my consumer's Pact configuration. This custom setting conflicts with the task.pattern default, resulting in `PactBroker::Client::Error: No pact files found`.  I had to dig into https://github.com/pact-foundation/pact_broker-client/blob/master/lib/pact_broker/client/tasks/publication_task.rb to figure out task.pattern. Hopefully this small change to the README will help future users. 😃  Thank you for a wonderful tool! I love Pact!