### PR TITLE
feat: docker file for running client. Handy for CICD (can-i-deploy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM ruby:2.5.3-alpine3.7
+RUN gem install pact_broker-client
+CMD ["/bin/sh"]


### PR DESCRIPTION
We are using client during CICD of our services to check if we can deploy consumer. Having docker image is handy, as you can just refer to it during the build process in travis/circleci/dron/gitlab etc.

I was not able to figure out yet how to integrate building and pushing docker image from your release process. Maybe someone who did it for https://github.com/DiUS/pact_broker-docker can help?