### PR TITLE
Use docker hub public link for the reference 

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,4 +231,4 @@ bundle exec rake pact:publish
 
 [wiki-tags]: https://github.com/pact-foundation/pact_broker/wiki/Using-tags
 [pact-ruby-standalone]: https://github.com/pact-foundation/pact-ruby-standalone/releases
-[docker]: https://cloud.docker.com/u/pactfoundation/repository/docker/pactfoundation/pact-cli
+[docker]: https://hub.docker.com/r/pactfoundation/pact-cli


### PR DESCRIPTION
Use docker hub public link for the docker image