### PR TITLE
Allow to pass pacticpant with equals sign to can-i-deploy

### DIFF
--- a/lib/pact_broker/client/cli/version_selector_options_parser.rb
+++ b/lib/pact_broker/client/cli/version_selector_options_parser.rb
@@ -5,6 +5,7 @@ module PactBroker
         def self.call options
           versions = []
           last_flag = nil
+          options = options.flat_map { |option| option.split('=') }
           options.each do | option |
             case option
             when "--pacticipant", "-a"

--- a/spec/integration/can_i_deploy_spec.rb
+++ b/spec/integration/can_i_deploy_spec.rb
@@ -27,6 +27,15 @@ describe "pact-broker can-i-deploy", skip_windows: true do
     end
   end
 
+  context "when flags are passed with equals sign" do
+    subject { `bundle exec bin/pact-broker can-i-deploy --pacticipant=Foo --version=1.2.3 --pacticipant=Bar --version=4.5.6 --broker-base-url=http://localhost:5000` }
+
+    it "returns a success exit code" do
+      subject
+      expect($?.exitstatus).to eq 0
+    end
+  end
+
   after(:all) do
     Process.kill 'KILL', @pipe.pid
   end


### PR DESCRIPTION
Fixes an issue when using `=` sign in `--pacticipant` would results in the error that pacticipant is not specified at all.

To reproduce, run the following command:

```
$ bundle exec pact-broker can-i-deploy --pacticipant=Foo --latest --broker-base-url=<broker-url>
Please specify the pacticipant name
```