### PR TITLE
Fix invalid environment variable names in can-i-deploy docs

### DIFF
--- a/lib/pact_broker/client/cli/can_i_deploy_long_desc.txt
+++ b/lib/pact_broker/client/cli/can_i_deploy_long_desc.txt
@@ -1,6 +1,6 @@
 Returns exit code 0 or 1, indicating whether or not the specified pacticipant versions are compatible. Prints out the relevant pact/verification details.
 
-The environment variables PACT_BROKER_BASE_URL, PACT_BROKER_BASE_URL_USERNAME and PACT_BROKER_BASE_URL_PASSWORD may be used instead of their respective command line options.
+The environment variables PACT_BROKER_BASE_URL, PACT_BROKER_USERNAME and PACT_BROKER_PASSWORD may be used instead of their respective command line options.
 
 SCENARIOS
 


### PR DESCRIPTION
The variables names are incorrect and should not contain `BASE_URL_`.