### PR TITLE
Update thor dependancy

### DIFF
--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'httparty', '~>0.18'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.7'
   gem.add_runtime_dependency 'table_print', '~> 1.5'
-  gem.add_runtime_dependency 'thor', '~> 0.20'
+  gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency 'rake', '~> 13.0' #For FileList
 
   gem.add_development_dependency 'fakefs', '~> 0.4'


### PR DESCRIPTION
I think current thor dependancy is not suitable. Latest `pact_broker-client` needs ``~> 0.20.0` but Rails 6 need thor v1.0.1.
Bundler try to install suitable version with its dependancy; thus latest version is v1.13.0 in Rails app.