### PR TITLE
Document broker communication parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Add `gem 'pact_broker-client'` to your Gemfile and run `bundle install`, or inst
 
 ## Usage - CLI
 
+The Pact Broker base URL can be specified either using the environment variable `$PACT_BROKER_BASE_URL` or the `-b` or `--broker-base-url` parameters.
+
+Pact Broker authentication can be performed either using basic auth or a bearer token.
+
+Basic auth parameters can be specified using the `$PACT_BROKER_USERNAME` and `$PACT_BROKER_PASSWORD` environment variables, or the `-u` or `--broker-username` and `-p` or `--broker-password` parameters.
+
+Authentication using a bearer token can be specified using the environment variable `$PACT_BROKER_TOKEN` or the `-k` or `--broker-token` parameters. This authentication system is used by [Pactflow](pactflow.io).
+
 To connect to a Pact Broker that uses custom SSL cerificates, set the environment variable `$SSL_CERT_FILE` or `$SSL_CERT_DIR` to a path that contains the appropriate certificate.
 
 ### publish


### PR DESCRIPTION
Fixes #77 

This documents the common parameters for communicating with Pact Brokers:

* Optional environment variables to use instead of command line parameters
* Go into a little more detail on which authentication options you have and what's required