### PR TITLE
feat: trim long versions on can-i-deploy formatting

### DIFF
--- a/lib/pact_broker/client/matrix/abbreviate_version_number.rb
+++ b/lib/pact_broker/client/matrix/abbreviate_version_number.rb
@@ -2,11 +2,28 @@ module PactBroker
   module Client
     class Matrix
       class AbbreviateVersionNumber
-        def self.call version_number
-          if version_number
-            version_number.gsub(/[A-Za-z0-9]{40}/) do | val |
-              val[0...7] + "..."
-            end
+        # Official regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        SEMVER_REGEX = /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
+        SHA1_REGEX = /[A-Za-z0-9]{40}/
+
+        class << self
+          def call version_number
+            return unless version_number
+
+            return replace_all_git_sha(version_number) if [SEMVER_REGEX, SHA1_REGEX].all?{|r| r.match?(version_number) }
+
+            return replace_all_git_sha(version_number) if Regexp.new("\\A#{SHA1_REGEX.source}\\z").match?(version_number)
+
+            # Trim to some meaningful value in case we couldn't match anything, just not to mess with the output
+            return version_number[0...60] + '...' if version_number.length > 60
+
+            version_number
+          end
+
+          private
+
+          def replace_all_git_sha(version)
+            version.gsub(SHA1_REGEX) { |val| val[0...7] + '...' }
           end
         end
       end

--- a/spec/lib/pact_broker/client/matrix/abbreviate_version_number_spec.rb
+++ b/spec/lib/pact_broker/client/matrix/abbreviate_version_number_spec.rb
@@ -1,0 +1,42 @@
+
+require 'pact_broker/client/matrix/abbreviate_version_number'
+
+module PactBroker
+  module Client
+    describe Matrix::AbbreviateVersionNumber do
+      describe '.call' do
+        subject(:result) { described_class.call(version) }
+
+        context 'when version is nil' do
+          let(:version) { nil }
+          it { is_expected.to be_nil }
+        end
+
+        context 'when version is git sha' do
+          let(:version) { '182f9c6e4d7a5779c4507cb8b3e505ac927d0394' }
+          it { is_expected.to eq('182f9c6...') }
+        end
+
+        context 'when version is too long' do
+          let(:version) { '182f9c6e4d7a5779c4507cb8b3e505ac927d0394' * 2 }
+          it { is_expected.to eq(version[0...60] + '...') }
+        end
+
+        context 'when the version is something unknown and fits max length' do
+          let(:version) { '123' }
+          it { is_expected.to eq('123') }
+        end
+
+        context 'when version is embedded into semantic version v1' do
+          let(:version) { 'v1.3.4+182f9c6e4d7a5779c4507cb8b3e505ac927d0394' }
+          it { is_expected.to eq('v1.3.4+182f9c6...') }
+        end
+
+        context 'when version is embedded into semantic version v2' do
+          let(:version) { '1.3.4(182f9c6e4d7a5779c4507cb8b3e505ac927d0394)' }
+          it { is_expected.to eq('1.3.4(182f9c6...)') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are using very long version numbers (to 2100 symbols) and lately, formatting has become really strange.
I don't know the idea behind the current code, so I don't know how to adapt it to a long version, so I just decided to trim it to 40 symbols.

<img width="1790" alt="Screenshot 2021-08-11 at 14 00 45" src="https://user-images.githubusercontent.com/1387057/129018057-2c729c37-4329-4aaf-ac7a-bc7352d9e2d1.png">
