### PR TITLE
feat: Add participant label options to webhook create/update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,8 +607,12 @@ Options:
               # Webhook basic auth username and password eg. username:password
       [--consumer=CONSUMER]                                                        
               # Consumer name
+      [--consumer-label=CONSUMER_LABEL]                                                        
+              # Consumer label
       [--provider=PROVIDER]                                                        
               # Provider name
+      [--provider-label=PROVIDER_LABEL]                                                        
+              # Provider label
       [--description=DESCRIPTION]                                                  
               # Webhook description
       [--contract-content-changed], [--no-contract-content-changed]                
@@ -663,8 +667,12 @@ Options:
               # Webhook basic auth username and password eg. username:password
       [--consumer=CONSUMER]                                                        
               # Consumer name
+      [--consumer-label=CONSUMER_LABEL]                                                        
+              # Consumer label
       [--provider=PROVIDER]                                                        
               # Provider name
+      [--provider-label=PROVIDER_LABEL]                                                        
+              # Provider label
       [--description=DESCRIPTION]                                                  
               # Webhook description
       [--contract-content-changed], [--no-contract-content-changed]                

--- a/doc/pacts/markdown/Pact Broker Client - Pact Broker.md
+++ b/doc/pacts/markdown/Pact Broker Client - Pact Broker.md
@@ -64,9 +64,13 @@
 
 * [A request to create a webhook with a JSON body for a consumer and provider](#a_request_to_create_a_webhook_with_a_JSON_body_for_a_consumer_and_provider_given_the_&#39;Pricing_Service&#39;_and_&#39;Condor&#39;_already_exist_in_the_pact-broker) given the 'Pricing Service' and 'Condor' already exist in the pact-broker
 
+* [A request to create a webhook with a JSON body for a consumer specified by a label](#a_request_to_create_a_webhook_with_a_JSON_body_for_a_consumer_specified_by_a_label)
+
 * [A request to create a webhook with a JSON body for a consumer that does not exist](#a_request_to_create_a_webhook_with_a_JSON_body_for_a_consumer_that_does_not_exist)
 
 * [A request to create a webhook with a JSON body for a provider](#a_request_to_create_a_webhook_with_a_JSON_body_for_a_provider_given_the_&#39;Pricing_Service&#39;_and_&#39;Condor&#39;_already_exist_in_the_pact-broker) given the 'Pricing Service' and 'Condor' already exist in the pact-broker
+
+* [A request to create a webhook with a JSON body for a provider specified by a label](#a_request_to_create_a_webhook_with_a_JSON_body_for_a_provider_specified_by_a_label)
 
 * [A request to create a webhook with a non-JSON body for a consumer and provider](#a_request_to_create_a_webhook_with_a_non-JSON_body_for_a_consumer_and_provider_given_the_&#39;Pricing_Service&#39;_and_&#39;Condor&#39;_already_exist_in_the_pact-broker) given the 'Pricing Service' and 'Condor' already exist in the pact-broker
 
@@ -1089,6 +1093,16 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -1222,6 +1236,16 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -1276,6 +1300,16 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -1327,6 +1361,80 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
+    "_links": {
+      "self": {
+        "href": "http://localhost:1234/some-url",
+        "title": "A title"
+      }
+    }
+  }
+}
+```
+<a name="a_request_to_create_a_webhook_with_a_JSON_body_for_a_consumer_specified_by_a_label"></a>
+Upon receiving **a request to create a webhook with a JSON body for a consumer specified by a label** from Pact Broker Client, with
+```json
+{
+  "method": "post",
+  "path": "/HAL-REL-PLACEHOLDER-PB-WEBHOOKS",
+  "headers": {
+    "Content-Type": "application/json",
+    "Accept": "application/hal+json"
+  },
+  "body": {
+    "description": "a webhook",
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
+    "request": {
+      "url": "https://webhook",
+      "method": "POST",
+      "headers": {
+        "Foo": "bar",
+        "Bar": "foo"
+      },
+      "body": {
+        "some": "body"
+      },
+      "username": "username",
+      "password": "password"
+    },
+    "consumer": {
+      "label": "consumer_label"
+    }
+  }
+}
+```
+Pact Broker will respond with:
+```json
+{
+  "status": 201,
+  "headers": {
+    "Content-Type": "application/hal+json;charset=utf-8"
+  },
+  "body": {
+    "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -1433,6 +1541,80 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
+    "_links": {
+      "self": {
+        "href": "http://localhost:1234/some-url",
+        "title": "A title"
+      }
+    }
+  }
+}
+```
+<a name="a_request_to_create_a_webhook_with_a_JSON_body_for_a_provider_specified_by_a_label"></a>
+Upon receiving **a request to create a webhook with a JSON body for a provider specified by a label** from Pact Broker Client, with
+```json
+{
+  "method": "post",
+  "path": "/HAL-REL-PLACEHOLDER-PB-WEBHOOKS",
+  "headers": {
+    "Content-Type": "application/json",
+    "Accept": "application/hal+json"
+  },
+  "body": {
+    "description": "a webhook",
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
+    "request": {
+      "url": "https://webhook",
+      "method": "POST",
+      "headers": {
+        "Foo": "bar",
+        "Bar": "foo"
+      },
+      "body": {
+        "some": "body"
+      },
+      "username": "username",
+      "password": "password"
+    },
+    "provider": {
+      "label": "provider_label"
+    }
+  }
+}
+```
+Pact Broker will respond with:
+```json
+{
+  "status": 201,
+  "headers": {
+    "Content-Type": "application/hal+json;charset=utf-8"
+  },
+  "body": {
+    "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -1482,6 +1664,14 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": "<xml></xml>"
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -1545,6 +1735,28 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      },
+      {
+        "name": "contract_published"
+      },
+      {
+        "name": "provider_verification_published"
+      },
+      {
+        "name": "provider_verification_succeeded"
+      },
+      {
+        "name": "provider_verification_failed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",
@@ -2550,6 +2762,16 @@ Pact Broker will respond with:
   },
   "body": {
     "description": "a webhook",
+    "request": {
+      "body": {
+        "some": "body"
+      }
+    },
+    "events": [
+      {
+        "name": "contract_content_changed"
+      }
+    ],
     "_links": {
       "self": {
         "href": "http://localhost:1234/some-url",

--- a/lib/pact_broker/client/webhooks/create.rb
+++ b/lib/pact_broker/client/webhooks/create.rb
@@ -81,10 +81,14 @@ module PactBroker
 
           if params.consumer
             body[:consumer] = { name: params.consumer }
+          elsif params.consumer_label
+            body[:consumer] = { label: params.consumer_label }
           end
 
           if params.provider
             body[:provider] = { name: params.provider }
+          elsif params.provider_label
+            body[:provider] = { label: params.provider_label }
           end
 
           if params.team_uuid

--- a/spec/pacts/pact_broker_client-pact_broker.json
+++ b/spec/pacts/pact_broker_client-pact_broker.json
@@ -1995,6 +1995,16 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2067,6 +2077,28 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            },
+            {
+              "name": "contract_published"
+            },
+            {
+              "name": "provider_verification_published"
+            },
+            {
+              "name": "provider_verification_succeeded"
+            },
+            {
+              "name": "provider_verification_failed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2125,6 +2157,14 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": "<xml></xml>"
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2323,6 +2363,88 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://localhost:1234/some-url",
+              "title": "A title"
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.description": {
+            "match": "type"
+          },
+          "$.body._links.self.href": {
+            "match": "regex",
+            "regex": "http:\\/\\/.*"
+          },
+          "$.body._links.self.title": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "a request to create a webhook with a JSON body for a consumer specified by a label",
+      "request": {
+        "method": "post",
+        "path": "/HAL-REL-PLACEHOLDER-PB-WEBHOOKS",
+        "headers": {
+          "Content-Type": "application/json",
+          "Accept": "application/hal+json"
+        },
+        "body": {
+          "description": "a webhook",
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
+          "request": {
+            "url": "https://webhook",
+            "method": "POST",
+            "headers": {
+              "Foo": "bar",
+              "Bar": "foo"
+            },
+            "body": {
+              "some": "body"
+            },
+            "username": "username",
+            "password": "password"
+          },
+          "consumer": {
+            "label": "consumer_label"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/hal+json;charset=utf-8"
+        },
+        "body": {
+          "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2442,6 +2564,88 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
+          "_links": {
+            "self": {
+              "href": "http://localhost:1234/some-url",
+              "title": "A title"
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.description": {
+            "match": "type"
+          },
+          "$.body._links.self.href": {
+            "match": "regex",
+            "regex": "http:\\/\\/.*"
+          },
+          "$.body._links.self.title": {
+            "match": "type"
+          }
+        }
+      }
+    },
+    {
+      "description": "a request to create a webhook with a JSON body for a provider specified by a label",
+      "request": {
+        "method": "post",
+        "path": "/HAL-REL-PLACEHOLDER-PB-WEBHOOKS",
+        "headers": {
+          "Content-Type": "application/json",
+          "Accept": "application/hal+json"
+        },
+        "body": {
+          "description": "a webhook",
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
+          "request": {
+            "url": "https://webhook",
+            "method": "POST",
+            "headers": {
+              "Foo": "bar",
+              "Bar": "foo"
+            },
+            "body": {
+              "some": "body"
+            },
+            "username": "username",
+            "password": "password"
+          },
+          "provider": {
+            "label": "provider_label"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/hal+json;charset=utf-8"
+        },
+        "body": {
+          "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2501,6 +2705,16 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2597,6 +2811,16 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",
@@ -2663,6 +2887,16 @@
         },
         "body": {
           "description": "a webhook",
+          "request": {
+            "body": {
+              "some": "body"
+            }
+          },
+          "events": [
+            {
+              "name": "contract_content_changed"
+            }
+          ],
           "_links": {
             "self": {
               "href": "http://localhost:1234/some-url",


### PR DESCRIPTION
Add `--consumer-label` and `--provider-label` options to webhook create/update commands.
Related to https://github.com/pact-foundation/pact_broker/pull/501
