### PR TITLE
fix: use ruby < 2.3 syntax.

### DIFF
--- a/lib/pact_broker/client/cli/version_commands.rb
+++ b/lib/pact_broker/client/cli/version_commands.rb
@@ -48,8 +48,8 @@ module PactBroker
               params = {
                 pacticipant_name: options.pacticipant.strip,
                 version_number: options.version.strip,
-                branch_name: options.branch&.strip,
-                tags: options.tag&.collect(&:strip)
+                branch_name: options.branch && options.branch.strip,
+                tags: options.tag && options.tag.collect(&:strip)
               }
 
               execute_version_command(params, "Create")


### PR DESCRIPTION
[v1.61.0](https://github.com/pact-foundation/pact_broker-client/releases/tag/v1.61.0) added code that uses ruby's safe navigation operator which was only available for ruby versions >= 2.3. Since this gem has ruby requirement of >= 2.0, this is creating issues for users using ruby < 2.3, such as users using the latest version (1.88.84) of [pact-foundation/pact-ruby-standalone](https://github.com/pact-foundation/pact-ruby-standalone) which ships with traveling ruby version of 2.2.