### PR TITLE
chore: bump ruby versions tested

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.2", "2.7"]
+        ruby_version: ["2.7", "3.0", "3.1"]
         experimental: [false]
-        include:
-          - ruby_version: "3.0"
-            experimental: true
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
       - run: "bundle install"
-      - if: failure()
-        run: cat /opt/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/gems/2.2.0/extensions/x86_64-linux/2.2.0/approvals-0.0.25/gem_make.out && exit 1
       - run: "bundle exec rake"
   pact:
     runs-on: "ubuntu-latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6-alpine3.12
+FROM ruby:3.1-alpine
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing hub
 RUN apk add --update --no-cache git openssh bash


### PR DESCRIPTION
* 2.6 is EOL and will no longer receive any updates, including security fixes. https://www.ruby-lang.org/en/downloads/branches/
* 2.2 has been EOL for more than four years now.
* 3.1 is now stable & current, not experimental.

This bumps the test matrix to purely the current versions of ruby, 2.7, 3.0 & 3.1

It also bumps the version of ruby in the Dockerfile to latest, but I don't think the Dockerfile is used to generate any distributed artifacts.

This goes along with the work to upgrade https://github.com/pact-foundation/pact-ruby-standalone from 2.2 to 2.4
