### PR TITLE
Relax httparty dependency restriction

### DIFF
--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.license       = 'MIT'
 
-  gem.add_runtime_dependency 'httparty', '~>0.18.1' # https://github.com/jnunemaker/httparty/issues/733
+  gem.add_runtime_dependency 'httparty', '~>0.18'
   gem.add_runtime_dependency 'term-ansicolor', '~> 1.7'
   gem.add_runtime_dependency 'table_print', '~> 1.5'
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'


### PR DESCRIPTION
Given that https://github.com/jnunemaker/httparty/issues/733 is resolved, this removes the restriction to stay on the 0.18 minor version of httparty.

Notably, the intent here is to allow for httparty to be updated in light of this issue: https://github.com/advisories/GHSA-5pq7-52mg-hr42.

httparty 0.21.0 has been released with a fix for this issue.