### PR TITLE
feat: colour first url in magenta for ease of reading

### DIFF
--- a/lib/pact_broker/client/base_command.rb
+++ b/lib/pact_broker/client/base_command.rb
@@ -94,8 +94,16 @@ module PactBroker
         ::Term::ANSIColor.blue(text)
       end
 
+      def magenta(text)
+        ::Term::ANSIColor.magenta(text)
+      end
+
       def red(text)
         ::Term::ANSIColor.red(text)
+      end
+
+      def yellow(text)
+        ::Term::ANSIColor.yellow(text)
       end
     end
   end

--- a/lib/pact_broker/client/colorize_notices.rb
+++ b/lib/pact_broker/client/colorize_notices.rb
@@ -1,5 +1,5 @@
 require 'term/ansicolor'
-
+require "uri"
 module PactBroker
   module Client
     class ColorizeNotices
@@ -11,16 +11,25 @@ module PactBroker
 
       def self.colorized_message(notice)
         color = color_for_type(notice.type)
-        if color
+        uri_string = ::URI.extract(notice.text, %w(http https))
+        if color && uri_string.count >= 1
+          color_for_url(::Term::ANSIColor.color(color, notice.text || ''), uri_string)
+        elsif color
           ::Term::ANSIColor.color(color, notice.text || '')
+        elsif uri_string.count >= 1
+          color_for_url(notice.text, uri_string)
         else
           notice.text
         end
       end
 
+      def self.color_for_url(text, uris)
+        text.gsub!(uris.first, ::Term::ANSIColor.magenta(uris.first))
+      end
+
       def self.color_for_type(type)
         case type
-        when "warning", "prompt" then "yellow"
+        when "warning", "prompt" then :yellow
         when "error", "danger" then :red
         when "success" then :green
         else nil

--- a/lib/pact_broker/client/colorize_notices.rb
+++ b/lib/pact_broker/client/colorize_notices.rb
@@ -11,20 +11,22 @@ module PactBroker
 
       def self.colorized_message(notice)
         color = color_for_type(notice.type)
-        uri_string = ::URI.extract(notice.text, %w(http https))
-        if color && uri_string.count >= 1
-          color_for_url(::Term::ANSIColor.color(color, notice.text || ''), uri_string)
+        uri_strings = ::URI.extract(notice.text, %w(http https))
+        if color && uri_strings.any?
+          color_for_url(::Term::ANSIColor.color(color, notice.text || ''), uri_strings)
         elsif color
           ::Term::ANSIColor.color(color, notice.text || '')
-        elsif uri_string.count >= 1
-          color_for_url(notice.text, uri_string)
+        elsif uri_strings.any?
+          color_for_url(notice.text, uri_strings)
         else
           notice.text
         end
       end
 
       def self.color_for_url(text, uris)
-        text.gsub!(uris.first, ::Term::ANSIColor.magenta(uris.first))
+        uris.inject(text) do | new_text, uri  |
+          new_text.gsub(uri, ::Term::ANSIColor.magenta(uri))
+        end
       end
 
       def self.color_for_type(type)

--- a/lib/pactflow/client/provider_contracts/publish.rb
+++ b/lib/pactflow/client/provider_contracts/publish.rb
@@ -43,10 +43,10 @@ module Pactflow
           [
             { type: 'prompt', text: 'Next steps:' },
             { type: 'prompt',
-              text: '   Check your application is safe to deploy - https://docs.pact.io/can_i_deploy' },
+              text: '  * Check your application is safe to deploy - https://docs.pact.io/can_i_deploy' },
             { text: "       pact-broker can-i-deploy --pacticipant #{provider_name} --version #{provider_version_number} --to-environment <your environment name>" },
             { type: 'prompt',
-              text: '   Record deployment or release to specified environment (choose one) - https://docs.pact.io/go/record-deployment :' },
+              text: '  * Record deployment or release to specified environment (choose one) - https://docs.pact.io/go/record-deployment' },
             { text: "       pact-broker record-deployment --pacticipant #{provider_name} --version #{provider_version_number} --environment <your environment name>" },
             { text: "       pact-broker record-release --pacticipant #{provider_name} --version #{provider_version_number} --environment <your environment name>" }
           ]

--- a/lib/pactflow/client/provider_contracts/publish.rb
+++ b/lib/pactflow/client/provider_contracts/publish.rb
@@ -1,5 +1,6 @@
 require "pact_broker/client/base_command"
 require "pact_broker/client/versions/create"
+require 'pact_broker/client/colorize_notices'
 require "base64"
 
 module Pactflow
@@ -26,23 +27,29 @@ module Pactflow
         end
 
         def render_response(res)
+          notices = [
+            { type: 'success', text: "Successfully published provider contract for #{provider_name} version #{provider_version_number} to Pactflow"},
+          ]
           if res.body && res.body['_links'] && res.body['_links']['pf:ui']['href']
-            ui_url = "\nView the uploaded contract at #{blue(res.body['_links']['pf:ui']['href'])}"
-            PactBroker::Client::CommandResult.new(true,
-                                                  green("Successfully published provider contract for #{provider_name} version #{provider_version_number} to Pactflow#{ui_url}#{next_steps}"))
-          else
-            PactBroker::Client::CommandResult.new(true,
-                                                  green("Successfully published provider contract for #{provider_name} version #{provider_version_number} to Pactflow#{next_steps}"))
+            notices.concat([{ text: "View the uploaded contract at #{res.body['_links']['pf:ui']['href']}" }])
           end
+          notices.concat(next_steps)
+          PactBroker::Client::CommandResult.new(true, PactBroker::Client::ColorizeNotices.call(notices.collect do |n|
+                                                                                                 OpenStruct.new(n)
+                                                                                               end).join("\n"))
         end
 
         def next_steps
-          [green("\nNext steps:\n"),
-           "    #{green("Check your application is safe to deploy - #{blue('https://docs.pact.io/can_i_deploy')}:\n")}",
-           "        #{"pact-broker can-i-deploy --pacticipant #{provider_name} --version #{provider_version_number} --to-environment <your environment name>\n"}",
-           "    #{green("Record deployment or release to specified environment (choose one) - #{blue('https://docs.pact.io/go/record-deployment')}:\n")}",
-           "        #{"pact-broker record-deployment --pacticipant #{provider_name} --version #{provider_version_number} --environment <your environment name>"}\n",
-           "        #{"pact-broker record-release --pacticipant #{provider_name} --version #{provider_version_number} --environment <your environment name>"}"].join('')
+          [
+            { type: 'prompt', text: 'Next steps:' },
+            { type: 'prompt',
+              text: '   Check your application is safe to deploy - https://docs.pact.io/can_i_deploy' },
+            { text: "       pact-broker can-i-deploy --pacticipant #{provider_name} --version #{provider_version_number} --to-environment <your environment name>" },
+            { type: 'prompt',
+              text: '   Record deployment or release to specified environment (choose one) - https://docs.pact.io/go/record-deployment :' },
+            { text: "       pact-broker record-deployment --pacticipant #{provider_name} --version #{provider_version_number} --environment <your environment name>" },
+            { text: "       pact-broker record-release --pacticipant #{provider_name} --version #{provider_version_number} --environment <your environment name>" }
+          ]
         end
 
         def create_branch_version_and_tags


### PR DESCRIPTION
## Automagically colour urls in log output

building on #118 it was identified that the colour contrast for the provider link was too dark and difficult to read on dark terminals.

### Messaging - User facing

Most times, your user may know what they need to do next, after interacting with the Pact Broker Client and a Pact Broker, however this is not always the case.

Authors should note that we use a mixture of text and colour, to convey

- actionable items
- informational items
- somethings gone awry items

We have tried to stick to these guidelines for user facing messages.

- `green` for success
- `white` for ancillary information
- `yellow` for next steps
- `red` for errors
- `magenta` for urls


So take for example publishing a pact.

- `green` successful publish
- `white` go and view your contract here
- `yellow` next steps

## Previous

![Screenshot 2023-05-04 at 17 39 02](https://user-images.githubusercontent.com/19932401/236269339-1334bee1-172d-4999-8e34-32b505045331.png)


## New


![Screenshot 2023-05-04 at 17 37 58](https://user-images.githubusercontent.com/19932401/236269114-48a2c9c2-45b4-4820-8c3b-da29594b6aac.png)

## Points of notice

Utilises the `colorized_message` functionality and uses the style of messaging sent from the pact broker, so this change also refactors the coloured messaging for the provider next steps, to make it a little bit more maintainable for the next developer.

Tested manually, should require a unit test

Condition will accept where there are more than one uri, but will only colour the first, I tried it in a loop, with an indexed array but no bueno

