### PR TITLE
fix: pact-broker --help command now returns help commands

### DIFF
--- a/lib/pact_broker/client/cli/custom_thor.rb
+++ b/lib/pact_broker/client/cli/custom_thor.rb
@@ -41,7 +41,7 @@ module PactBroker
           end
 
           def self.add_broker_config_from_environment_variables argv
-            return argv if argv[0] == 'help' || argv.empty?
+            return argv if argv[0] == '--help' || argv[0] == 'help' || argv.empty?
 
             add_option_from_environment_variable(argv, 'broker-base-url', 'b', 'PACT_BROKER_BASE_URL')
           end


### PR DESCRIPTION
Fixes the `pact-broker --help` command, so it doesn't attempt to source pact broker env vars`

prior behaviour

```console
bundle exec bin/pact-broker --help 
Could not find command "__broker_base_url".
```


```console
bundle exec bin/pact-broker help   
Commands:
  pact-broker can-i-deploy -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL                                                          # 
  pact-broker create-environment --name=NAME -b, --broker-base-url=BROKER_BASE_URL                                                                      # Create an environment resource in the Pact Broker to represent a real world deployment or release environment.
  pact-broker create-or-update-pacticipant --name=NAME -b, --broker-base-url=BROKER_BASE_URL                                                            # Create or update pacticipant by name
  pact-broker create-or-update-version -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION                        # Create or update pacticipant version by version number
  pact-broker create-or-update-webhook URL --uuid=UUID -X, --request=METHOD -b, --broker-base-url=BROKER_BASE_URL                                       # Creates or updates a webhook with a provided uuid and using the same switches as a curl request.
  pact-broker create-version-tag -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION                              # Add a tag to a pacticipant version
  pact-broker create-webhook URL -X, --request=METHOD -b, --broker-base-url=BROKER_BASE_URL                                                             # Creates a webhook using the same switches as a curl request.
  pact-broker delete-environment --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                      # Delete an environment
  pact-broker describe-environment --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                    # Describe an environment
  pact-broker describe-pacticipant --name=NAME -b, --broker-base-url=BROKER_BASE_URL                                                                    # Describe a pacticipant
  pact-broker describe-version -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL                                                      # Describes a pacticipant version. If no version or tag is specified, the latest version is described.
  pact-broker generate-uuid                                                                                                                             # Generate a UUID for use when calling create-or-update-webhook
  pact-broker help [COMMAND]                                                                                                                            # Describe available commands or one specific command
  pact-broker list-environments -b, --broker-base-url=BROKER_BASE_URL                                                                                   # List environments
  pact-broker list-latest-pact-versions -b, --broker-base-url=BROKER_BASE_URL                                                                           # List the latest pact for each integration
  pact-broker list-pacticipants -b, --broker-base-url=BROKER_BASE_URL                                                                                   # List pacticipants
  pact-broker publish PACT_DIRS_OR_FILES ... -a, --consumer-app-version=CONSUMER_APP_VERSION -b, --broker-base-url=BROKER_BASE_URL                      # Publish pacts to a Pact Broker.
  pact-broker record-deployment --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION     # Record deployment of a pacticipant version to an environment. See https://docs.pact.io/go/record-deployment f...
  pact-broker record-release --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION        # Record release of a pacticipant version to an environment. See See https://docs.pact.io/go/record-release for...
  pact-broker record-support-ended --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION  # Record the end of support for a pacticipant version in an environment. See https://docs.pact.io/go/record-sup...
  pact-broker record-undeployment --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL                         # Record undeployment of a pacticipant from an environment.
  pact-broker test-webhook --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                            # Test the execution of a webhook
  pact-broker update-environment --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                      # Update an environment resource in the Pact Broker.
  pact-broker version                                                                                                                                   # Show the pact_broker-client gem version
```


## Post change

```console
git checkout fix/help_command  
Alias tip: gco fix/help_command
M       .ruby-version
Switched to branch 'fix/help_command'
Your branch is up to date with 'origin/fix/help_command'.

pact_broker-client on  fix/help_command [$!] via 🐳 desktop-linux via 💎 v3.2.2 on ☁️  (eu-west-2) 
🕙18:37:35 ❯ bundle exec bin/pact-broker --help
Commands:
  pact-broker can-i-deploy -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL                                                          # 
  pact-broker create-environment --name=NAME -b, --broker-base-url=BROKER_BASE_URL                                                                      # Create an environment resource in the Pact Broker to represent a real world deployment or release environment.
  pact-broker create-or-update-pacticipant --name=NAME -b, --broker-base-url=BROKER_BASE_URL                                                            # Create or update pacticipant by name
  pact-broker create-or-update-version -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION                        # Create or update pacticipant version by version number
  pact-broker create-or-update-webhook URL --uuid=UUID -X, --request=METHOD -b, --broker-base-url=BROKER_BASE_URL                                       # Creates or updates a webhook with a provided uuid and using the same switches as a curl request.
  pact-broker create-version-tag -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION                              # Add a tag to a pacticipant version
  pact-broker create-webhook URL -X, --request=METHOD -b, --broker-base-url=BROKER_BASE_URL                                                             # Creates a webhook using the same switches as a curl request.
  pact-broker delete-environment --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                      # Delete an environment
  pact-broker describe-environment --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                    # Describe an environment
  pact-broker describe-pacticipant --name=NAME -b, --broker-base-url=BROKER_BASE_URL                                                                    # Describe a pacticipant
  pact-broker describe-version -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL                                                      # Describes a pacticipant version. If no version or tag is specified, the latest version is described.
  pact-broker generate-uuid                                                                                                                             # Generate a UUID for use when calling create-or-update-webhook
  pact-broker help [COMMAND]                                                                                                                            # Describe available commands or one specific command
  pact-broker list-environments -b, --broker-base-url=BROKER_BASE_URL                                                                                   # List environments
  pact-broker list-latest-pact-versions -b, --broker-base-url=BROKER_BASE_URL                                                                           # List the latest pact for each integration
  pact-broker list-pacticipants -b, --broker-base-url=BROKER_BASE_URL                                                                                   # List pacticipants
  pact-broker publish PACT_DIRS_OR_FILES ... -a, --consumer-app-version=CONSUMER_APP_VERSION -b, --broker-base-url=BROKER_BASE_URL                      # Publish pacts to a Pact Broker.
  pact-broker record-deployment --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION     # Record deployment of a pacticipant version to an environment. See https://docs.pact.io/go/record-deployment f...
  pact-broker record-release --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION        # Record release of a pacticipant version to an environment. See See https://docs.pact.io/go/record-release for...
  pact-broker record-support-ended --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL -e, --version=VERSION  # Record the end of support for a pacticipant version in an environment. See https://docs.pact.io/go/record-sup...
  pact-broker record-undeployment --environment=ENVIRONMENT -a, --pacticipant=PACTICIPANT -b, --broker-base-url=BROKER_BASE_URL                         # Record undeployment of a pacticipant from an environment.
  pact-broker test-webhook --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                            # Test the execution of a webhook
  pact-broker update-environment --uuid=UUID -b, --broker-base-url=BROKER_BASE_URL                                                                      # Update an environment resource in the Pact Broker.
  pact-broker version                                                                                                                                   # Show the pact_broker-client gem version
```

`bundle exec bin/pact-broker help` behaviour same as above :)