### PR TITLE
fix: verification-required command invalid arg number

### DIFF
--- a/lib/pact_broker/client/cli/matrix_commands.rb
+++ b/lib/pact_broker/client/cli/matrix_commands.rb
@@ -88,7 +88,7 @@ module PactBroker
                 selectors = VersionSelectorOptionsParser.call(ARGV)
                 validate_can_i_deploy_selectors(selectors)
                 verification_required_options = { output: options.output, verbose: options.verbose, retry_while_unknown: 0 }
-                result = VerificationRequired.call(options.broker_base_url, selectors, { to_tag: options.to, to_environment: options.in_environment, ignore_selectors: [] }, verification_required_options, pact_broker_client_options)
+                result = VerificationRequired.call(selectors, { to_tag: options.to, to_environment: options.in_environment, ignore_selectors: [] }, verification_required_options, pact_broker_client_options)
                 $stdout.puts result.message
                 $stdout.flush
                 exit(1) unless result.success


### PR DESCRIPTION


Trying out this command returned the following error

`PACT_BROKER_FEATURES=verification_required pact-broker verification-required --pacticipant=FrontEndService --version foo`

Error:-

```
/opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.74.0/lib/pact_broker/client/can_i_deploy.rb:22:in `call': wrong number of arguments (given 5, expected 3..4) (ArgumentError)
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.74.0/lib/pact_broker/client/cli/matrix_commands.rb:91:in `verification_required'
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/thor-1.2.2/lib/thor/base.rb:485:in `start'
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.74.0/lib/pact_broker/client/cli/custom_thor.rb:34:in `start'
	from /opt/homebrew/Cellar/pact-ruby-standalone/2.0.9/lib/app/pact-broker.rb:34:in `<main>'
```

Removing the additional argument in the command, got it working

Returns exit code 1 - where no verification is required

<img width="1959" alt="Screenshot 2023-11-23 at 18 13 52" src="https://github.com/pact-foundation/pact_broker-client/assets/19932401/5834d474-7147-43f7-a249-42a99e72c9d4">

Returns exit code 0 - when verification is required

<img width="1711" alt="Screenshot 2023-11-23 at 18 14 41" src="https://github.com/pact-foundation/pact_broker-client/assets/19932401/836d48eb-fd10-42d1-9002-1fadaf63db31">

