### PR TITLE
fix: openstruct broken unless explicit require of ostruct

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["2.7", "3.0", "3.1", "3.2"]
+        ruby_version: ["2.7", "3.0", "3.1", "3.2", "3.3"]
         os: ["ubuntu-latest","windows-latest","macos-latest"]
     steps:
       - uses: actions/checkout@v4

--- a/lib/pact_broker/client/pacts/list_latest_versions.rb
+++ b/lib/pact_broker/client/pacts/list_latest_versions.rb
@@ -1,6 +1,7 @@
 require 'pact_broker/client/hal'
 require 'pact_broker/client/command_result'
 require 'pact_broker/client/hal_client_methods'
+require 'ostruct'
 
 module PactBroker
   module Client

--- a/lib/pact_broker/client/publish_pacts.rb
+++ b/lib/pact_broker/client/publish_pacts.rb
@@ -4,6 +4,7 @@ require 'base64'
 require 'pact_broker/client/publish_pacts_the_old_way'
 require 'pact_broker/client/colorize_notices'
 require 'pact_broker/client/hash_refinements'
+require 'ostruct'
 
 module PactBroker
   module Client

--- a/lib/pact_broker/client/webhooks/create.rb
+++ b/lib/pact_broker/client/webhooks/create.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'pact_broker/client/command_result'
 require "pact_broker/client/backports"
 require "pact_broker/client/hash_refinements"
+require 'ostruct'
 
 module PactBroker
   module Client

--- a/lib/pactflow/client/provider_contracts/publish.rb
+++ b/lib/pactflow/client/provider_contracts/publish.rb
@@ -2,6 +2,7 @@ require "base64"
 require "pact_broker/client/base_command"
 require "pact_broker/client/colorize_notices"
 require "pactflow/client/provider_contracts/publish_the_old_way"
+require 'ostruct'
 
 module Pactflow
   module Client

--- a/lib/pactflow/client/provider_contracts/publish_the_old_way.rb
+++ b/lib/pactflow/client/provider_contracts/publish_the_old_way.rb
@@ -2,6 +2,7 @@ require "pact_broker/client/base_command"
 require "pact_broker/client/versions/create"
 require 'pact_broker/client/colorize_notices'
 require "base64"
+require 'ostruct'
 
 module Pactflow
   module Client

--- a/spec/integration/can_i_merge_spec.rb
+++ b/spec/integration/can_i_merge_spec.rb
@@ -1,4 +1,5 @@
 require "pact_broker/client/cli/broker"
+require 'ostruct'
 
 module PactBroker
   module Client

--- a/spec/lib/pact_broker/client/cli/broker_can_i_deploy_spec.rb
+++ b/spec/lib/pact_broker/client/cli/broker_can_i_deploy_spec.rb
@@ -1,6 +1,7 @@
 require 'pact_broker/client/cli/broker'
 require 'pact_broker/client/cli/version_selector_options_parser'
 require 'pact_broker/client/can_i_deploy'
+require 'ostruct'
 
 module PactBroker
   module Client

--- a/spec/lib/pact_broker/client/cli/broker_publish_spec.rb
+++ b/spec/lib/pact_broker/client/cli/broker_publish_spec.rb
@@ -1,6 +1,7 @@
 require 'pact_broker/client/cli/broker'
 require 'pact_broker/client/publish_pacts'
 require 'pact_broker/client/git'
+require 'ostruct'
 
 module PactBroker::Client::CLI
   describe Broker do

--- a/spec/lib/pact_broker/client/cli/broker_run_webhook_commands_spec.rb
+++ b/spec/lib/pact_broker/client/cli/broker_run_webhook_commands_spec.rb
@@ -1,5 +1,6 @@
 require 'pact_broker/client/cli/broker'
 require 'pact_broker/client/webhooks/create'
+require 'ostruct'
 
 module PactBroker
   module Client

--- a/spec/lib/pactflow/client/provider_contracts/publish_spec.rb
+++ b/spec/lib/pactflow/client/provider_contracts/publish_spec.rb
@@ -1,4 +1,5 @@
 require "pactflow/client/provider_contracts/publish"
+require 'ostruct'
 
 module Pactflow
   module Client


### PR DESCRIPTION
So as of the latest release of pact-ruby-cli, we had some errors reported

`NameError - uninitialized constant Pactflow::Client::ProviderContracts::Publish::OpenStruct`

https://github.com/pact-foundation/pact-ruby-cli/issues/131

passing the following env var

`-e RUBYOPT="-rostruct"`

fixes it, temporarily for end users.

```sh
docker run -v $PWD:/home --rm -it -e PACT_BROKER_TOKEN -e PACT_BROKER_BASE_URL -e RUBYOPT="-rostruct" pactfoundation/pact-cli:latest pactflow publish-provider-contract /home/example/provider-contracts/oas.yml --provider foo --provider-app-version foo1 --content-type application/yaml 
```

Interesting, re-running our CI today, with no code changes other than adding in ruby 3.3 to the matrix, resulted in the same test failures.

https://github.com/pact-foundation/pact_broker-client/actions/runs/9066772247/job/24910431506

across Ruby 2.7 - Ruby 3.3

I wondered if it was because there was a new release of Rubies, on 2024-04-23 but that was only for Ruby 3.0.x and upwards, where we see failures today on Ruby 2.7, which we did not see 3 months ago.

Explicitly requiring 'ostruct' has resolved the test failures, but hasn't aided in reducing my confusion as to how this has suddenly manifested!

edit: to further muddy the water, I was able to successfully run the tests on my mac with ruby 3.2.4 without these changes 😅 (it also passes after) 🤷🏾‍♂️ 