### PR TITLE
Deps/add base64

### DIFF
--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'thor', '>= 0.20', '< 2.0'
   gem.add_runtime_dependency 'rake', '~> 13.0' #For FileList
   gem.add_runtime_dependency 'dig_rb', '~> 1.0'
+  gem.add_runtime_dependency 'base64', '~> 0.2'
 end

--- a/spec/support/ssl_server.rb
+++ b/spec/support/ssl_server.rb
@@ -36,7 +36,7 @@ if __FILE__ == $0
 
   opts = webrick_opts(4444)
 
-  Rack::Handler::WEBrick.run(app, **opts) do |server|
+  Rackup::Handler::WEBrick.run(app, **opts) do |server|
     @server = server
   end
 end


### PR DESCRIPTION
`warning: base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.`

Fixes #158 