### PR TITLE
feat(can-i-deploy): skip --retry-while-unknown if --dry-run true

### DIFF
--- a/lib/pact_broker/client/can_i_deploy.rb
+++ b/lib/pact_broker/client/can_i_deploy.rb
@@ -109,7 +109,7 @@ module PactBroker
 
       def fetch_matrix_with_retries
         matrix = fetch_matrix
-        if retry_while_unknown?
+        if retry_while_unknown? && !dry_run_or_false
           check_if_retry_while_unknown_supported(matrix)
           if matrix.any_unknown?
             results = matrix.unknown_count == 1 ? "result" : "results"

--- a/spec/lib/pact_broker/client/can_i_deploy_spec.rb
+++ b/spec/lib/pact_broker/client/can_i_deploy_spec.rb
@@ -163,9 +163,9 @@ module PactBroker
               expect(subject.success).to be true
             end
 
-            it "returns a failure message" do
+            it "returns a success message" do
               expect(subject.message).to include "[dry-run]"
-              expect(subject.message).to match /does not provide a count/
+              expect(subject.message).to match /Dry run enabled - ignoring any failures/
             end
           end
         end


### PR DESCRIPTION
fixes #149

When --dry-run is enabled, --retry-while-unknown will no longer take effect. 
