### PR TITLE
fix: missing list_latest_versions due to loose regex on gem files

### DIFF
--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Client for the Pact Broker. Publish, retrieve and query pacts and verification results. Manage webhooks and environments.}
   gem.summary       = %q{See description}
   gem.homepage      = "https://github.com/pact-foundation/pact_broker-client.git"
-  gem.files         = `git ls-files`.split($/).reject { |file| file.match(/(test|spec|features)/) }
+  gem.files         = `git ls-files`.split($/).reject { |file| file.match(/(test\/|spec\/|features\/|.github\/)/) }
 
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]

--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Client for the Pact Broker. Publish, retrieve and query pacts and verification results. Manage webhooks and environments.}
   gem.summary       = %q{See description}
   gem.homepage      = "https://github.com/pact-foundation/pact_broker-client.git"
-  gem.files         = `git ls-files`.split($/).reject { |file| file.match(/(test\/|spec\/|features\/|.github\/)/) }
+  gem.files         = `git ls-files`.split($/).reject { |file| file.match(/(test\/|spec\/|.github\/)/) }
 
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/pact-foundation/pact_broker-client/pull/168.

Raised on slack <internal:/usr/local/lib/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- pact_broker/client/pacts/list_latest_versions (LoadError)
        from <internal:/usr/local/lib/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
        from /usr/lib/ruby/gems/3.3.0/gems/pact_broker-client-1.76.0/lib/pact_broker/client/cli/pact_commands.rb:44:in `list_latest_pact_versions'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
        from /usr/lib/ruby/gems/3.3.0/gems/pact_broker-client-1.76.0/lib/pact_broker/client/cli/custom_thor.rb:34:in `start'
        from /usr/lib/ruby/gems/3.3.0/gems/pact_broker-client-1.76.0/bin/pact-broker:10:in `<top (required)>'
        from /usr/bin/pact-broker:25:in `load'
        from /usr/bin/pact-broker:25:in `<main>'

```
<internal:/usr/local/lib/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- pact_broker/client/pacts/list_latest_versions (LoadError)
        from <internal:/usr/local/lib/site_ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
        from /usr/lib/ruby/gems/3.3.0/gems/pact_broker-client-1.76.0/lib/pact_broker/client/cli/pact_commands.rb:44:in `list_latest_pact_versions'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
        from /usr/lib/ruby/gems/3.3.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
        from /usr/lib/ruby/gems/3.3.0/gems/pact_broker-client-1.76.0/lib/pact_broker/client/cli/custom_thor.rb:34:in `start'
        from /usr/lib/ruby/gems/3.3.0/gems/pact_broker-client-1.76.0/bin/pact-broker:10:in `<top (required)>'
        from /usr/bin/pact-broker:25:in `load'
        from /usr/bin/pact-broker:25:in `<main>'
```

whereby we are excluding files from being included in the gem, however we were looking for any path+filename that includes *test* which captures `lib/pact_broker/client/pacts/list_latest_versions.rb`

This change updates the rejection list to only include `spec/`, `test/`, `.github/`.

It also removes`features` (not sure why I included that before for exclusion)

