### PR TITLE
fix: ostruct was loaded from the standard library

### DIFF
--- a/pact-broker-client.gemspec
+++ b/pact-broker-client.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rake', '~> 13.0' #For FileList
   gem.add_runtime_dependency 'dig_rb', '~> 1.0'
   gem.add_runtime_dependency 'base64', '~> 0.2'
+  gem.add_runtime_dependency 'ostruct'
 end


### PR DESCRIPTION
Fixes issue #173

This PR addresses the warning related to the `ostruct` library being removed from the standard library in Ruby 3.5.0 by adding it as an explicit dependency in the gemspec file. 