### PR TITLE
feat: set user agent on requests

### DIFF
--- a/lib/pact_broker/client/base_client.rb
+++ b/lib/pact_broker/client/base_client.rb
@@ -3,6 +3,7 @@
 require 'erb'
 require 'httparty'
 require 'pact_broker/client/error'
+require 'pact_broker/client/user_agent'
 require 'cgi'
 
 module PactBroker
@@ -104,15 +105,16 @@ module PactBroker
       end
 
       def patch url, options
-        self.class.patch(url, @default_options.merge(options.merge(body: options[:body].to_json)))
+        enriched = enrich_options(options)
+        self.class.patch(url, @default_options.merge(enriched.merge(body: options[:body].to_json)))
       end
 
       def put url, options = {}, &block
-        self.class.put(url, @default_options.merge(options), &block)
+        self.class.put(url, @default_options.merge(enrich_options(options)), &block)
       end
 
       def get url, options = {}, &block
-        self.class.get(url, @default_options.merge(options), &block)
+        self.class.get(url, @default_options.merge(enrich_options(options)), &block)
       end
 
       def url_for_relation relation_name, params
@@ -132,6 +134,16 @@ module PactBroker
 
       def verbose?
         @verbose
+      end
+
+      private
+
+      def enrich_options(options)
+        options.merge(headers: user_agent_header.merge(options.fetch(:headers, {})))
+      end
+
+      def user_agent_header
+        { 'User-Agent' => PactBroker::Client.user_agent_string('httparty', HTTParty::VERSION) }
       end
     end
   end

--- a/lib/pact_broker/client/hal/http_client.rb
+++ b/lib/pact_broker/client/hal/http_client.rb
@@ -1,5 +1,6 @@
 require 'pact_broker/client/retry'
 require 'pact_broker/client/hal/authorization_header_redactor'
+require 'pact_broker/client/user_agent'
 require 'net/http'
 require 'json'
 require 'openssl'
@@ -58,6 +59,9 @@ module PactBroker
           request.body = body if body
           request.basic_auth username, password if username
           request['Authorization'] = "Bearer #{token}" if token
+          unless headers.any? { |k, _| k.downcase == 'user-agent' }
+            request['User-Agent'] = PactBroker::Client.user_agent_string('net-http', Net::HTTP::VERSION)
+          end
           request
         end
 

--- a/lib/pact_broker/client/user_agent.rb
+++ b/lib/pact_broker/client/user_agent.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'pact_broker/client/version'
+
+module PactBroker
+  module Client
+    class << self
+      attr_accessor :tool_identifier
+
+      def user_agent_string(http_lib_name, http_lib_version)
+        base = "pact_broker-client/#{VERSION} #{http_lib_name}/#{http_lib_version} ruby/#{RUBY_VERSION}"
+        if tool_identifier && !tool_identifier.empty?
+          "#{tool_identifier} #{base}"
+        else
+          base
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/pact_broker/client/base_client_spec.rb
+++ b/spec/lib/pact_broker/client/base_client_spec.rb
@@ -177,6 +177,61 @@ module PactBroker
           end
         end
       end
+
+      describe 'User-Agent header' do
+        around do |example|
+          original = PactBroker::Client.tool_identifier
+          example.run
+          PactBroker::Client.tool_identifier = original
+        end
+
+        let(:expected_ua) { "pact_broker-client/#{VERSION} httparty/#{HTTParty::VERSION} ruby/#{RUBY_VERSION}" }
+
+        context 'without tool_identifier' do
+          before { PactBroker::Client.tool_identifier = nil }
+
+          let!(:request) do
+            stub_request(:get, "#{base_url}/")
+              .with(headers: { 'User-Agent' => expected_ua })
+              .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it 'sends the default user agent on GET requests' do
+            subject.get('/')
+            expect(request).to have_been_made
+          end
+        end
+
+        context 'with tool_identifier set' do
+          before { PactBroker::Client.tool_identifier = 'pact-standalone/9.9.9' }
+
+          let!(:request) do
+            stub_request(:get, "#{base_url}/")
+              .with(headers: { 'User-Agent' => "pact-standalone/9.9.9 #{expected_ua}" })
+              .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it 'prepends the tool identifier' do
+            subject.get('/')
+            expect(request).to have_been_made
+          end
+        end
+
+        context 'when caller supplies a User-Agent header' do
+          before { PactBroker::Client.tool_identifier = nil }
+
+          let!(:request) do
+            stub_request(:get, "#{base_url}/")
+              .with(headers: { 'User-Agent' => 'custom/1.0' })
+              .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it 'preserves the caller-supplied value' do
+            subject.get('/', headers: { 'User-Agent' => 'custom/1.0' })
+            expect(request).to have_been_made
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/pact_broker/client/hal/http_client_spec.rb
+++ b/spec/lib/pact_broker/client/hal/http_client_spec.rb
@@ -7,6 +7,58 @@ module PactBroker::Client
     describe HttpClient do
       subject { HttpClient.new(username: 'foo', password: 'bar') }
 
+      describe "User-Agent header" do
+        before do
+          allow(subject).to receive(:until_truthy_or_max_times) { |&block| block.call }
+          PactBroker::Client.tool_identifier = nil
+        end
+
+        after { PactBroker::Client.tool_identifier = nil }
+
+        let(:expected_ua) { "pact_broker-client/#{PactBroker::Client::VERSION} net-http/#{Net::HTTP::VERSION} ruby/#{RUBY_VERSION}" }
+
+        context "without tool_identifier" do
+          let!(:request) do
+            stub_request(:get, "http://example.org/")
+              .with(headers: { 'User-Agent' => expected_ua })
+              .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it "sends the default user agent" do
+            subject.get('http://example.org')
+            expect(request).to have_been_made
+          end
+        end
+
+        context "with tool_identifier set" do
+          before { PactBroker::Client.tool_identifier = 'pact-standalone/9.9.9' }
+
+          let!(:request) do
+            stub_request(:get, "http://example.org/")
+              .with(headers: { 'User-Agent' => "pact-standalone/9.9.9 #{expected_ua}" })
+              .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it "prepends the tool identifier" do
+            subject.get('http://example.org')
+            expect(request).to have_been_made
+          end
+        end
+
+        context "when User-Agent is supplied in headers" do
+          let!(:request) do
+            stub_request(:get, "http://example.org/")
+              .with(headers: { 'User-Agent' => 'custom/1.0' })
+              .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it "preserves the caller-supplied value" do
+            subject.get('http://example.org', {}, { 'User-Agent' => 'custom/1.0' })
+            expect(request).to have_been_made
+          end
+        end
+      end
+
       describe "get" do
         before do
           allow(subject).to receive(:until_truthy_or_max_times) { |&block| block.call }

--- a/spec/lib/pact_broker/client/user_agent_spec.rb
+++ b/spec/lib/pact_broker/client/user_agent_spec.rb
@@ -1,0 +1,50 @@
+require 'pact_broker/client/user_agent'
+
+module PactBroker
+  module Client
+    describe '.user_agent_string' do
+      around do |example|
+        original = PactBroker::Client.tool_identifier
+        example.run
+        PactBroker::Client.tool_identifier = original
+      end
+
+      context 'without tool_identifier' do
+        before { PactBroker::Client.tool_identifier = nil }
+
+        it 'returns the base user agent string' do
+          expect(PactBroker::Client.user_agent_string('net-http', '1.2.3')).to eq(
+            "pact_broker-client/#{VERSION} net-http/1.2.3 ruby/#{RUBY_VERSION}"
+          )
+        end
+      end
+
+      context 'with tool_identifier set' do
+        before { PactBroker::Client.tool_identifier = 'pact-standalone/9.9.9' }
+
+        it 'prepends the tool identifier' do
+          expect(PactBroker::Client.user_agent_string('net-http', '1.2.3')).to eq(
+            "pact-standalone/9.9.9 pact_broker-client/#{VERSION} net-http/1.2.3 ruby/#{RUBY_VERSION}"
+          )
+        end
+      end
+
+      context 'with tool_identifier set to empty string' do
+        before { PactBroker::Client.tool_identifier = '' }
+
+        it 'returns the base user agent string without prefix' do
+          expect(PactBroker::Client.user_agent_string('net-http', '1.2.3')).to eq(
+            "pact_broker-client/#{VERSION} net-http/1.2.3 ruby/#{RUBY_VERSION}"
+          )
+        end
+      end
+
+      context 'tool_identifier= and tool_identifier' do
+        it 'can be set and retrieved' do
+          PactBroker::Client.tool_identifier = 'my-tool/1.0'
+          expect(PactBroker::Client.tool_identifier).to eq 'my-tool/1.0'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will help identify traffic from this library, and also provides a way for downstream libraries to further customise the user agent.