### PR TITLE
test: resolve pact-v2 failures

### DIFF
--- a/spec/pact/providers/PactBroker/extra_goodies_spec.rb
+++ b/spec/pact/providers/PactBroker/extra_goodies_spec.rb
@@ -6,7 +6,7 @@ module PactBroker::Client
   describe PactBrokerClient, :pact => true do
 
     pact_broker
-    let(:pact_broker_client) { PactBrokerClient.new(base_url: 'http://localhost:9999') }
+    let(:pact_broker_client) { PactBrokerClient.new(base_url: 'http://127.0.0.1:9999') }
 
     describe "listing pacts" do
       context "when pacts exist" do

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -26,5 +26,5 @@ end
 
 shared_context "pact broker - pact-ruby-v2" do
   let(:pact_hash) { PactBroker::Client::PactHash[consumer: {name: 'Condor'}, interactions: [], provider: {name: 'Pricing Service'}] }
-  let(:broker_base_url) { 'http://localhost:9999' }
+  let(:broker_base_url) { 'http://127.0.0.1:9999' }
 end


### PR DESCRIPTION
Newer versions of HTTParty raise UnsafeURIError when following a link whose host differs from the configured base_uri, even when the two hosts resolve to the same address (127.0.0.1 vs localhost).

The pact mock server binds to 127.0.0.1:9999 and generates response URLs with that host, but the test client was configured with localhost:9999. HTTParty rejected the mismatch, causing the first versions spec test to fail without properly tearing down the mock server, which cascaded into 21 further failures with "Address already in use".

Fix by aligning the broker_base_url in the pact-ruby-v2 shared context and extra_goodies_spec.rb to use 127.0.0.1, matching the mock server.